### PR TITLE
Add GlobalPrompts node and credentials

### DIFF
--- a/credentials/GlobalPrompts.credentials.ts
+++ b/credentials/GlobalPrompts.credentials.ts
@@ -1,0 +1,46 @@
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+export const GLOBAL_PROMPTS_CREDENTIALS_NAME = 'globalPrompts';
+
+export class GlobalPromptsCredentials implements ICredentialType {
+  name = GLOBAL_PROMPTS_CREDENTIALS_NAME;
+  displayName = 'Global Prompts';
+
+  properties: INodeProperties[] = [
+    {
+      displayName: 'Prompts',
+      name: 'prompts',
+      type: 'fixedCollection',
+      default: {},
+      typeOptions: {
+        multipleValues: true,
+        multipleValueButtonText: 'Add Prompt',
+      },
+      options: [
+        {
+          displayName: 'Prompt',
+          name: 'prompt',
+          values: [
+            {
+              displayName: 'Prompt Text',
+              name: 'text',
+              type: 'string',
+              default: '',
+              typeOptions: {
+                rows: 4,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+export interface GlobalPromptsCredentialsData {
+  prompts: {
+    prompt: Array<{
+      text: string;
+    }>;
+  };
+}

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
 import { Example } from './nodes/Example/Example.node';
+import { GlobalPrompts } from './nodes/GlobalPrompts/GlobalPrompts.node';
 
-export const nodes = [Example];
+export const nodes = [Example, GlobalPrompts];

--- a/nodes/GlobalPrompts/GlobalPrompts.node.ts
+++ b/nodes/GlobalPrompts/GlobalPrompts.node.ts
@@ -1,0 +1,89 @@
+import {
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeType,
+  INodeTypeDescription,
+  NodeConnectionType,
+} from 'n8n-workflow';
+import {
+  GLOBAL_PROMPTS_CREDENTIALS_NAME,
+  GlobalPromptsCredentialsData,
+} from '../../credentials/GlobalPrompts.credentials';
+
+export class GlobalPrompts implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'Global Prompts',
+    name: 'globalPrompts',
+    icon: 'file:globalprompts.svg',
+    group: ['transform', 'output'],
+    version: 1,
+    description: 'Insert prompts from credentials',
+    defaults: {
+      name: 'Global Prompts',
+    },
+    inputs: [NodeConnectionType.Main],
+    outputs: [NodeConnectionType.Main],
+    credentials: [
+      {
+        name: GLOBAL_PROMPTS_CREDENTIALS_NAME,
+        required: true,
+      },
+    ],
+    properties: [
+      {
+        displayName: 'Put All Prompts in One Key',
+        name: 'putAllInOneKey',
+        type: 'boolean',
+        default: true,
+        description: 'Whether to put all prompts in a single key',
+      },
+      {
+        displayName: 'Prompts Key Name',
+        name: 'promptsKeyName',
+        type: 'string',
+        default: 'prompts',
+        displayOptions: {
+          show: {
+            putAllInOneKey: [true],
+          },
+        },
+        description: 'Name of the key to store all prompts under',
+      },
+    ],
+  };
+
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const credentials = (await this.getCredentials(
+      GLOBAL_PROMPTS_CREDENTIALS_NAME,
+    )) as unknown as GlobalPromptsCredentialsData;
+
+    const promptTexts = credentials.prompts?.prompt?.map((p) => p.text) || [];
+
+    const putAllInOneKey = this.getNodeParameter('putAllInOneKey', 0) as boolean;
+
+    let promptsData: { [key: string]: any } = {};
+
+    if (putAllInOneKey) {
+      const promptsKeyName = this.getNodeParameter('promptsKeyName', 0) as string;
+      promptsData = { [promptsKeyName]: promptTexts };
+    } else {
+      promptTexts.forEach((text, index) => {
+        promptsData[`prompt${index + 1}`] = text;
+      });
+    }
+
+    const returnData = this.getInputData();
+    if (returnData.length === 0) {
+      returnData.push({ json: promptsData });
+    } else {
+      returnData.forEach((item) => {
+        item.json = {
+          ...item.json,
+          ...promptsData,
+        };
+      });
+    }
+
+    return [returnData];
+  }
+}

--- a/nodes/GlobalPrompts/globalprompts.svg
+++ b/nodes/GlobalPrompts/globalprompts.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#4CAF50" />
+  <text x="50" y="60" font-size="40" text-anchor="middle" fill="#ffffff">E</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -34,22 +34,25 @@
   ],
   "n8n": {
     "n8nNodesApiVersion": 1,
-    "credentials": [],
+    "credentials": [
+      "dist/credentials/GlobalPrompts.credentials.js"
+    ],
     "nodes": [
-      "dist/nodes/Example/Example.node.js"
+      "dist/nodes/Example/Example.node.js",
+      "dist/nodes/GlobalPrompts/GlobalPrompts.node.js"
     ]
   },
   "devDependencies": {
-    "@types/node": "^20.17.47",
+    "@types/node": "^20.17.57",
     "@typescript-eslint/parser": "~8.32.0",
+    "c8": "^8.0.1",
     "eslint": "^8.57.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.3",
     "gulp": "^5.0.0",
     "prettier": "^3.5.3",
-    "typescript": "^5.8.2",
-    "c8": "^8.0.1"
+    "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "n8n-workflow": "*"
+    "n8n-workflow": "^1.82.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `GlobalPrompts` credentials with flexible prompt fields
- create `GlobalPrompts` node that injects prompts from credentials
- expose new node

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a5f0a2c80832bb292a393079ff647